### PR TITLE
Bugfixes for chrome and firefox

### DIFF
--- a/src/frame-highdetail-black.svg
+++ b/src/frame-highdetail-black.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?> <!-- Created with Vectornator for iOS (http://vectornator.io/) --><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg height="100%" style="fill-rule:nonzero;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="100%" xmlns:vectornator="http://vectornator.io" version="1.1" viewBox="0 0 305.188 305.188">
+<svg width="250px" height="250px" style="fill-rule:nonzero;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" xmlns:vectornator="http://vectornator.io" version="1.1" viewBox="0 0 305.188 305.188">
 <metadata>
 <vectornator:setting key="DimensionsVisible" value="1"/>
 <vectornator:setting key="PencilOnly" value="0"/>

--- a/src/frame-highdetail-white.svg
+++ b/src/frame-highdetail-white.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?> <!-- Created with Vectornator for iOS (http://vectornator.io/) --><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg height="100%" style="fill-rule:nonzero;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="100%" xmlns:vectornator="http://vectornator.io" version="1.1" viewBox="0 0 305.188 305.188">
+<svg width="250px" height="250px" style="fill-rule:nonzero;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" xmlns:vectornator="http://vectornator.io" version="1.1" viewBox="0 0 305.188 305.188">
 <metadata>
 <vectornator:setting key="DimensionsVisible" value="1"/>
 <vectornator:setting key="PencilOnly" value="0"/>

--- a/src/styles.css
+++ b/src/styles.css
@@ -108,6 +108,7 @@ a.set-border.rainbow {
 a.set-border.rainbow > span {
   background: linear-gradient(to right, red 0%, #ff0 17%, lime 33%, cyan 50%, #f0f 83%, red 100%);
   background-clip: text;
+  -webkit-background-clip: text; /* necessary for Chrome */
   -webkit-text-fill-color: transparent;  /* works with Firefox too! */
 }
 a#export:hover,


### PR DESCRIPTION
- highdetail frames weren't working in firefox, was fixed by adding concrete sizes to the svg files
- pride button was rendering like this in chrome 
![image](https://user-images.githubusercontent.com/606355/176154244-348759b7-3199-4ede-9137-160fc993084e.png)
