### PR TITLE
File picker and zoom slider

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -17,11 +17,13 @@
   <a href="javascript:setBorder('frame-caste-black.png')" class="set-border black">caste equity</a>
 </div>
 
-<div id="image-frame">
-  <canvas></canvas>
-  <input type="file" required />
-</div>
+<h2 id="instructions">📷 Choose your photo 📷</h2>
 
-<a id="export" download="avatar.png">Save</a>
+<input type="file" required />
+<canvas width=400 height=400></canvas>
+
+<p><a id="export" download="avatar.png">Save</a></p>
+
+<p><small>(your image is not uploaded or saved by this webpage)</small></p>
 
 <script src="script.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -6,15 +6,22 @@
 
 <h1>AWU profile image generator</h1>
 <p>Choose an image to add an AWU profile frame to it!</p>
-<div id="frame-list">
-  Frame style:
-  <a href="javascript:setBorder(0.69, 'frame-black.png')"            class="button black">black</a>
-  <a href="javascript:setBorder(0.67, 'frame-highdetail-black.svg')" class="button black">black (high detail)</a>
-  <a href="javascript:setBorder(0.69, 'frame-white.png')"            class="button white" id="frame-list-default">white</a>
-  <a href="javascript:setBorder(0.67, 'frame-highdetail-white.svg')" class="button white">white (high detail)</a>
-  <a href="javascript:setBorder(0.68, 'frame-pride.png')"            class="button rainbow"><span>pride</span></a>
-  <a href="javascript:setBorder(0.69, 'frame-trans.png')"            class="button trans white"><span>trans</span></a>
-  <a href="javascript:setBorder(0.68, 'frame-caste-black.png')"      class="button black">caste equity</a>
+<div id="frame-list" class="frame-sublist">
+  <div class="frame-sublist">
+    <div class="frame-sublist">
+      <a href="javascript:setBorder(0.69, 'frame-black.png')"            class="button black">black</a>
+      <a href="javascript:setBorder(0.67, 'frame-highdetail-black.svg')" class="button black">black (high detail)</a>
+    </div>
+    <div class="frame-sublist">
+      <a href="javascript:setBorder(0.69, 'frame-white.png')"            class="button white" id="frame-list-default">white</a>
+      <a href="javascript:setBorder(0.67, 'frame-highdetail-white.svg')" class="button white">white (high detail)</a>
+    </div>
+  </div>
+  <div class="frame-sublist">
+    <a href="javascript:setBorder(0.68, 'frame-pride.png')"            class="button rainbow"><span>pride</span></a>
+    <a href="javascript:setBorder(0.69, 'frame-trans.png')"            class="button trans white"><span>trans</span></a>
+    <a href="javascript:setBorder(0.68, 'frame-caste-black.png')"      class="button black">caste equity</a>
+  </div>
 </div>
 
 <h2 id="instructions">📷 Choose your photo 📷</h2>

--- a/src/index.html
+++ b/src/index.html
@@ -6,15 +6,15 @@
 
 <h1>AWU profile image generator</h1>
 <p>Choose an image to add an AWU profile frame to it!</p>
-<div>
+<div id="frame-list">
   Frame style:
-  <a href="javascript:setBorder(0.69, 'frame-black.png')" class="set-border black">black</a>
-  <a href="javascript:setBorder(0.67, 'frame-highdetail-black.svg')" class="set-border black">black (high detail)</a>
-  <a href="javascript:setBorder(0.69, 'frame-white.png')" class="set-border white">white</a>
-  <a href="javascript:setBorder(0.67, 'frame-highdetail-white.svg')" class="set-border white">white (high detail)</a>
-  <a href="javascript:setBorder(0.68, 'frame-pride.png')" class="set-border rainbow"><span>pride</span></a>
-  <a href="javascript:setBorder(0.69, 'frame-trans.png')" class="set-border trans white"><span>trans</span></a>
-  <a href="javascript:setBorder(0.68, 'frame-caste-black.png')" class="set-border black">caste equity</a>
+  <a href="javascript:setBorder(0.69, 'frame-black.png')"            class="button black">black</a>
+  <a href="javascript:setBorder(0.67, 'frame-highdetail-black.svg')" class="button black">black (high detail)</a>
+  <a href="javascript:setBorder(0.69, 'frame-white.png')"            class="button white" id="frame-list-default">white</a>
+  <a href="javascript:setBorder(0.67, 'frame-highdetail-white.svg')" class="button white">white (high detail)</a>
+  <a href="javascript:setBorder(0.68, 'frame-pride.png')"            class="button rainbow"><span>pride</span></a>
+  <a href="javascript:setBorder(0.69, 'frame-trans.png')"            class="button trans white"><span>trans</span></a>
+  <a href="javascript:setBorder(0.68, 'frame-caste-black.png')"      class="button black">caste equity</a>
 </div>
 
 <h2 id="instructions">📷 Choose your photo 📷</h2>
@@ -23,7 +23,7 @@
 
 <canvas width=400 height=400></canvas>
 
-<p><a id="export" download="avatar.png">Save</a></p>
+<p><a id="export" class="button" download="avatar.png">Save</a></p>
 
 <p><small>(your image is not uploaded or saved by this webpage)</small></p>
 

--- a/src/index.html
+++ b/src/index.html
@@ -8,18 +8,20 @@
 <p>Choose an image to add an AWU profile frame to it!</p>
 <div>
   Frame style:
-  <a href="javascript:setBorder('frame-black.png')" class="set-border black">black</a>
-  <a href="javascript:setBorder('frame-highdetail-black.svg')" class="set-border black">black (high detail)</a>
-  <a href="javascript:setBorder('frame-white.png')" class="set-border white">white</a>
-  <a href="javascript:setBorder('frame-highdetail-white.svg')" class="set-border white">white (high detail)</a>
-  <a href="javascript:setBorder('frame-pride.png')" class="set-border rainbow"><span>pride</span></a>
-  <a href="javascript:setBorder('frame-trans.png')" class="set-border trans white"><span>trans</span></a>
-  <a href="javascript:setBorder('frame-caste-black.png')" class="set-border black">caste equity</a>
+  <a href="javascript:setBorder('red', 'frame-black.png')" class="set-border black">black</a>
+  <a href="javascript:setBorder('red', 'frame-highdetail-black.svg')" class="set-border black">black (high detail)</a>
+  <a href="javascript:setBorder('red', 'frame-white.png')" class="set-border white">white</a>
+  <a href="javascript:setBorder('red', 'frame-highdetail-white.svg')" class="set-border white">white (high detail)</a>
+  <a href="javascript:setBorder('red', 'frame-pride.png')" class="set-border rainbow"><span>pride</span></a>
+  <a href="javascript:setBorder('#f5abb9', 'frame-trans.png')" class="set-border trans white"><span>trans</span></a>
+  <a href="javascript:setBorder('red', 'frame-caste-black.png')" class="set-border black">caste equity</a>
 </div>
 
 <h2 id="instructions">📷 Choose your photo 📷</h2>
 
 <input type="file" required />
+
+<input id="zoomInput" type="range" min="0.5" max="1.0" step="0.01" value="0.7"/>
 <canvas width=400 height=400></canvas>
 
 <p><a id="export" download="avatar.png">Save</a></p>

--- a/src/index.html
+++ b/src/index.html
@@ -8,13 +8,13 @@
 <p>Choose an image to add an AWU profile frame to it!</p>
 <div>
   Frame style:
-  <a href="javascript:setBorder('frame-black.png')" class="set-border black">black</a>
-  <a href="javascript:setBorder('frame-highdetail-black.svg')" class="set-border black">black (high detail)</a>
-  <a href="javascript:setBorder('frame-white.png')" class="set-border white">white</a>
-  <a href="javascript:setBorder('frame-highdetail-white.svg')" class="set-border white">white (high detail)</a>
-  <a href="javascript:setBorder('frame-pride.png')" class="set-border rainbow"><span>pride</span></a>
-  <a href="javascript:setBorder('frame-trans.png')" class="set-border trans white"><span>trans</span></a>
-  <a href="javascript:setBorder('frame-caste-black.png')" class="set-border black">caste equity</a>
+  <a href="javascript:setBorder(0.69, 'frame-black.png')" class="set-border black">black</a>
+  <a href="javascript:setBorder(0.67, 'frame-highdetail-black.svg')" class="set-border black">black (high detail)</a>
+  <a href="javascript:setBorder(0.69, 'frame-white.png')" class="set-border white">white</a>
+  <a href="javascript:setBorder(0.67, 'frame-highdetail-white.svg')" class="set-border white">white (high detail)</a>
+  <a href="javascript:setBorder(0.68, 'frame-pride.png')" class="set-border rainbow"><span>pride</span></a>
+  <a href="javascript:setBorder(0.69, 'frame-trans.png')" class="set-border trans white"><span>trans</span></a>
+  <a href="javascript:setBorder(0.68, 'frame-caste-black.png')" class="set-border black">caste equity</a>
 </div>
 
 <h2 id="instructions">📷 Choose your photo 📷</h2>

--- a/src/index.html
+++ b/src/index.html
@@ -8,20 +8,19 @@
 <p>Choose an image to add an AWU profile frame to it!</p>
 <div>
   Frame style:
-  <a href="javascript:setBorder('red', 'frame-black.png')" class="set-border black">black</a>
-  <a href="javascript:setBorder('red', 'frame-highdetail-black.svg')" class="set-border black">black (high detail)</a>
-  <a href="javascript:setBorder('red', 'frame-white.png')" class="set-border white">white</a>
-  <a href="javascript:setBorder('red', 'frame-highdetail-white.svg')" class="set-border white">white (high detail)</a>
-  <a href="javascript:setBorder('red', 'frame-pride.png')" class="set-border rainbow"><span>pride</span></a>
-  <a href="javascript:setBorder('#f5abb9', 'frame-trans.png')" class="set-border trans white"><span>trans</span></a>
-  <a href="javascript:setBorder('red', 'frame-caste-black.png')" class="set-border black">caste equity</a>
+  <a href="javascript:setBorder('frame-black.png')" class="set-border black">black</a>
+  <a href="javascript:setBorder('frame-highdetail-black.svg')" class="set-border black">black (high detail)</a>
+  <a href="javascript:setBorder('frame-white.png')" class="set-border white">white</a>
+  <a href="javascript:setBorder('frame-highdetail-white.svg')" class="set-border white">white (high detail)</a>
+  <a href="javascript:setBorder('frame-pride.png')" class="set-border rainbow"><span>pride</span></a>
+  <a href="javascript:setBorder('frame-trans.png')" class="set-border trans white"><span>trans</span></a>
+  <a href="javascript:setBorder('frame-caste-black.png')" class="set-border black">caste equity</a>
 </div>
 
 <h2 id="instructions">📷 Choose your photo 📷</h2>
 
 <input type="file" required />
 
-<input id="zoomInput" type="range" min="0.5" max="1.0" step="0.01" value="0.7"/>
 <canvas width=400 height=400></canvas>
 
 <p><a id="export" download="avatar.png">Save</a></p>

--- a/src/placeholder.svg
+++ b/src/placeholder.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" width="400px" height="400px" viewBox="0 0 400 400" style="background:gray"></svg>

--- a/src/placeholder.svg
+++ b/src/placeholder.svg
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" width="400px" height="400px" viewBox="0 0 400 400" style="background:gray"></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="400px" height="400px" viewBox="0 0 400 400" style="background:#00000000"></svg>

--- a/src/script.js
+++ b/src/script.js
@@ -30,15 +30,27 @@ function drawCanvas() {
   const innerWidth  = (size / sizeUnclamped) * width;
   const innerHeight = (size / sizeUnclamped) * height;
   const center = size / 2;
-  
-  context.arc(size/2, size/2, size/2, 0, 2 * Math.PI);
-  context.clip();
 
-  context.fillStyle = frameImageBGColor;
-  context.fillRect(0, 0, size, size);
-  context.drawImage(uploadedImage,
-    center - innerWidth / 2, center - innerHeight / 2,
-    innerWidth, innerHeight);
+  // Clip a few extra pixels off the edge so the uploaded image never bleeds
+  // through at the borders of the frame
+  const kExtraClip = 2;
+  context.arc(size/2, size/2, size/2 - kExtraClip, 0, 2 * Math.PI);
+  {
+    context.save();
+    {
+      context.clip();
+
+      context.fillStyle = frameImageBGColor;
+      context.fillRect(0, 0, size, size);
+      context.imageSmoothingQuality = 'high';
+      context.drawImage(uploadedImage,
+        center - innerWidth / 2, center - innerHeight / 2,
+        innerWidth, innerHeight);
+    }
+    context.restore();
+  }
+  // Draw the frame without clipping. Generally, the frame should have its own
+  // border transparency.
   context.drawImage(frameImage, 0, 0, size, size);
 
   const canvas = document.querySelector('canvas');

--- a/src/script.js
+++ b/src/script.js
@@ -3,6 +3,7 @@ const context = document.querySelector("canvas").getContext("2d");
 const frameImage = new Image();
 frameImage.src = 'frame-white.png';
 const uploadedImage = new Image();
+uploadedImage.src = 'placeholder.svg';
 
 function drawCanvas() {
   if (!uploadedImage.src) return;

--- a/src/script.js
+++ b/src/script.js
@@ -1,9 +1,7 @@
 const context = document.querySelector("canvas").getContext("2d");
-const zoomInput = document.querySelector("#zoomInput");
 
 const frameImage = new Image();
 frameImage.src = 'frame-white.png';
-let frameImageBGColor = 'red';
 const uploadedImage = new Image();
 uploadedImage.src = 'placeholder.svg';
 
@@ -17,8 +15,7 @@ function drawCanvas() {
   const {width, height} = uploadedImage;
   const maxDimension = Math.max(width, height);
 
-  const zoom = zoomInput.value;
-  const sizeUnclamped = Math.floor(maxDimension / zoom / 2) * 2;
+  const sizeUnclamped = Math.floor(maxDimension / 2) * 2;
   // Try to set things up so the image in the middle retains its original
   // resolution. But don't let the frame resolution get too low, or the final
   // resolution get too large. (Firefox in particular doesn't downscale well,
@@ -40,8 +37,6 @@ function drawCanvas() {
     {
       context.clip();
 
-      context.fillStyle = frameImageBGColor;
-      context.fillRect(0, 0, size, size);
       context.imageSmoothingQuality = 'high';
       context.drawImage(uploadedImage,
         center - innerWidth / 2, center - innerHeight / 2,
@@ -59,7 +54,6 @@ function drawCanvas() {
 }
 frameImage.addEventListener("load", drawCanvas);
 uploadedImage.addEventListener("load", drawCanvas);
-zoomInput.addEventListener("input", drawCanvas);
 
 function readImage() {
   if (!this.files || !this.files[0]) return;
@@ -73,7 +67,6 @@ function readImage() {
 document.querySelector("input[type='file']")
     .addEventListener("change", readImage);
 
-function setBorder(bgColor, filename) {
+function setBorder(filename) {
   frameImage.src = filename;
-  frameImageBGColor = bgColor;
 }

--- a/src/script.js
+++ b/src/script.js
@@ -1,7 +1,13 @@
 const context = document.querySelector("canvas").getContext("2d");
 
 const frameImage = new Image();
+// TODO: The initial values for frameImage.src and frameInnerToOuterRatio
+// are duplicated between here and index.html. Find a way to avoid that.
 frameImage.src = 'frame-white.png';
+// Ratio between the inner size of the frame (where the uploaded image gets
+// drawn) to the outer size of the frame.
+let frameInnerToOuterRatio = 0.69;
+
 const uploadedImage = new Image();
 uploadedImage.src = 'placeholder.svg';
 
@@ -13,9 +19,9 @@ function drawCanvas() {
   context.beginPath();
 
   const {width, height} = uploadedImage;
-  const maxDimension = Math.max(width, height);
+  const minDimension = Math.min(width, height);
 
-  const sizeUnclamped = Math.floor(maxDimension / 2) * 2;
+  const sizeUnclamped = Math.floor(minDimension / frameInnerToOuterRatio / 2) * 2;
   // Try to set things up so the image in the middle retains its original
   // resolution. But don't let the frame resolution get too low, or the final
   // resolution get too large. (Firefox in particular doesn't downscale well,
@@ -30,11 +36,11 @@ function drawCanvas() {
 
   // Clip a few extra pixels off the edge so the uploaded image never bleeds
   // through at the borders of the frame
-  const kExtraClip = 2;
-  context.arc(size/2, size/2, size/2 - kExtraClip, 0, 2 * Math.PI);
   {
     context.save();
     {
+      const kExtraClip = 2;
+      context.arc(size/2, size/2, size/2 - kExtraClip, 0, 2 * Math.PI);
       context.clip();
 
       context.imageSmoothingQuality = 'high';
@@ -67,6 +73,7 @@ function readImage() {
 document.querySelector("input[type='file']")
     .addEventListener("change", readImage);
 
-function setBorder(filename) {
+function setBorder(innerToOuterRatio, filename) {
   frameImage.src = filename;
+  frameInnerToOuterRatio = innerToOuterRatio;
 }

--- a/src/script.js
+++ b/src/script.js
@@ -1,16 +1,5 @@
 const context = document.querySelector("canvas").getContext("2d");
 
-const frameImage = new Image();
-// TODO: The initial values for frameImage.src and frameInnerToOuterRatio
-// are duplicated between here and index.html. Find a way to avoid that.
-frameImage.src = 'frame-white.png';
-// Ratio between the inner size of the frame (where the uploaded image gets
-// drawn) to the outer size of the frame.
-let frameInnerToOuterRatio = 0.69;
-
-const uploadedImage = new Image();
-uploadedImage.src = 'placeholder.svg';
-
 function drawCanvas() {
   if (!uploadedImage.src) return;
 
@@ -58,8 +47,6 @@ function drawCanvas() {
   const exportLink = document.querySelector('#export');
   exportLink.href = canvas.toDataURL('image/png');
 }
-frameImage.addEventListener("load", drawCanvas);
-uploadedImage.addEventListener("load", drawCanvas);
 
 function readImage() {
   if (!this.files || !this.files[0]) return;
@@ -77,3 +64,17 @@ function setBorder(innerToOuterRatio, filename) {
   frameImage.src = filename;
   frameInnerToOuterRatio = innerToOuterRatio;
 }
+
+const uploadedImage = new Image();
+uploadedImage.src = 'placeholder.svg';
+uploadedImage.addEventListener("load", drawCanvas);
+
+const frameImage = new Image();
+frameImage.src = '';
+frameImage.addEventListener("load", drawCanvas);
+// Ratio between the inner size of the frame (where the uploaded image gets
+// drawn) to the outer size of the frame.
+let frameInnerToOuterRatio = 0;
+
+// Trigger the default frame to set the defaults for the above.
+document.querySelector('#frame-list-default').click();

--- a/src/styles.css
+++ b/src/styles.css
@@ -51,7 +51,21 @@ a.button:focus {
   text-decoration: underline;
 }
 
+#frame-list {
+  width: 100%;
+  max-width: 800px;
+}
+/* The frame-sublist structure in HTML provides control over line-breaking in flexbox */
+.frame-sublist {
+  flex: auto;
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+}
+
 #frame-list a.button {
+  flex: auto;
+  text-align: center;
   background: red;
   border-color: black;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,66 +12,19 @@ h1 {
   padding: 0;
 }
 
-#image-frame {
-  height: 400px;
-  width: 400px;
-  position: relative;
-  margin: 40px;
+#instructions {
+  margin-bottom: 0;
 }
-
-#image-frame * {
-  position: absolute;
-  width: 400px;
-  top: 0;
-  left: 0;
-}
-
-canvas {
-  z-index: 0;
-}
-
-img {
-  z-index: 1;
-}
-
 input[type="file"] {
-  font-family: inherit;
-  height: 100%;
-  z-index: 10;
-}
-input[type="file"]::-webkit-file-upload-button {
-  opacity: 0;
-}
-input[type="file"]::file-selector-button {
-  opacity: 0;
-}
-
-input[type="file"]:valid {
-  display: none;
-}
-input[type="file"]:invalid {
-  background: #eee;
-  color: transparent;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-input[type="file"]:invalid::before {
-  color: black;
-  content: '📷 Click to choose your photo 📷';
-  display: block;
-  font-size: 2em;
-  font-weight: bold;
+  max-width: 100%;
+  margin: 0.5em;
   text-align: center;
-  margin-top: 200px;
-  transform: translateY(-100%);
+  font-size: 110%;
+  border: thin solid gray;
 }
-input[type="file"]:invalid::after {
-  color: black;
-  content: '(does not upload! image processing happens in your browser)';
-  display: block;
-  text-align: center;
-  margin: 0;
+canvas {
+  width: 100%;
+  max-width: 400px;
 }
 
 a#export {

--- a/src/styles.css
+++ b/src/styles.css
@@ -25,6 +25,8 @@ input[type="file"] {
 canvas {
   width: 100%;
   max-width: 400px;
+  background-color: lightgray;
+  border-radius: 1em;
 }
 
 a#export {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,5 +1,5 @@
 body {
-  height: 100vh;
+  margin: 5vh 1em;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/styles.css
+++ b/src/styles.css
@@ -25,8 +25,11 @@ input[type="file"] {
 canvas {
   width: 100%;
   max-width: 400px;
-  background-color: lightgray;
-  border-radius: 1em;
+  /* Fallback background color */
+  background-color: #aaa;
+  /* Checkerboard pattern with a size of 5x5% repeating = 20x20 repeats */
+  background: repeating-conic-gradient(#999 0deg 90deg, #bbb 90deg 180deg) center / 5% 5%;
+  border-radius: 2.5%;
 }
 
 a#export {

--- a/src/styles.css
+++ b/src/styles.css
@@ -16,11 +16,14 @@ h1 {
   margin-bottom: 0;
 }
 input[type="file"] {
-  max-width: 100%;
-  margin: 0.5em;
-  text-align: center;
+  width: 100%;
+  max-width: 400px;
+  box-sizing: border-box;
+  margin: 0.5em 0;
   font-size: 110%;
-  border: thin solid gray;
+  background: lightgray;
+  border-radius: 10px;
+  padding: 5px;
 }
 canvas {
   width: 100%;
@@ -29,14 +32,10 @@ canvas {
   background-color: #aaa;
   /* Checkerboard pattern with a size of 5x5% repeating = 20x20 repeats */
   background: repeating-conic-gradient(#999 0deg 90deg, #bbb 90deg 180deg) center / 5% 5%;
-  border-radius: 2.5%;
+  border-radius: 10px;
 }
 
-a#export {
-  display: none;
-}
-a#export:link,
-a.set-border {
+a.button {
   display: inline-block;
   background: #eee;
   border: 1px solid #888;
@@ -47,31 +46,30 @@ a.set-border {
   padding: 0.25em 1em;
   text-decoration: none;
 }
-a.set-border {
+a.button:hover,
+a.button:focus {
+  text-decoration: underline;
+}
+
+#frame-list a.button {
   background: red;
   border-color: black;
 }
-a.set-border.black {
+#frame-list a.button.black {
   color: black;
 }
-a.set-border.white {
+#frame-list a.button.white {
   color: white;
 }
-a.set-border.trans {
+#frame-list a.button.trans {
   background: linear-gradient(to bottom, #5bcffa 0%, #5bcffa 49%, #f5abb9 51%, #f5abb9 100%);
 }
-a.set-border.rainbow {
+#frame-list a.button.rainbow {
   background: black;
 }
-a.set-border.rainbow > span {
+#frame-list a.button.rainbow > span {
   background: linear-gradient(to right, red 0%, #ff0 17%, lime 33%, cyan 50%, #f0f 83%, red 100%);
   background-clip: text;
   -webkit-background-clip: text; /* necessary for Chrome */
   -webkit-text-fill-color: transparent;  /* works with Firefox too! */
-}
-a#export:hover,
-a#export:focus,
-a.set-border:hover,
-a.set-border:focus {
-  text-decoration: underline;
 }


### PR DESCRIPTION
Just the result of my hacking away - feedback super welcome!

- always show the file picker so that you can reupload without reloading the page. Also, reloading the page was broken in firefox (file picker would not come back after reload)
- allow the page to scroll if it gets too tall, instead of trying to squash (this is mostly a problem because I added more stuff to the page vertically... unfortunately)
- add a zoom slider, defaulting to "just" fit the uploaded image inside the frame (instead of having the frame cover up a bunch of it)
- disable clipping of the avatar frame itself so we preserve the cool flourishes around the edges